### PR TITLE
Contribution to use FDMNES and FDMNES_SPACEGROUP environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ pyFDMNES
 Python interface to fdmnes simulations. Simplifies and automates data input/output.
 - load cif files
 - Read/Modify/Write FDMNES input files
-- easily perform repeated `Colvolution` on existing DOS calculation
+- easily perform repeated `Convolution` on existing DOS calculation
 - flexibly extract `DAFS`/`XANES` curves from existing calculation
 
-A new FDMNES simulation is represented by the `fdmnes` object which  can be created by loading an existing (manually created) fdmnes input file, a .cif file of by defining space-group or metric and subsequently fill the unit cell with atoms.
+A new FDMNES simulation is represented by the `fdmnes` object which  can be created by loading an existing (manually created) FDMNES input file, a `.cif` file of by defining space-group or metric and subsequently fill the unit cell with atoms.
 
-After loading an existing input file, one can for example change some parameters in the `fdmnes.P` Parameter instance and save/create new inputfiles with WriteInputFile. One can add the saved file to the job queue which can be executed using sim.Run().
+After loading an existing input file, one can for example change some parameters in the `fdmnes.P` Parameter instance and save/create new input files with `WriteInputFile`. One can add the saved file to the job queue which can be executed using sim.Run().
 
 Furthermore, the `fdmnes.P` Parameters Object similar to a python dict but does some consistency check of all given parameters, to a certain extent. Basically it checks if the given parameter has the proper shape (2d, 1d, 0d, or bool, etc..). How the definitions are stored, can be seen in the settings file:
-https://github.com/tinaw/pyFDMNES/blob/master/fdmnes/settings.py The idea is also to identify parameters which are crucial for the computation of the matrix elements and others which are used for post-processing (e.g. Convolution). This would allow to let pyFDMNES decide when a new computation of the matrix elements or electron density is necessary.
+[fdmnes/settings.py](fdmnes/settings.py) The idea is also to identify parameters which are crucial for the computation of the matrix elements and others which are used for post-processing (e.g. Convolution). This would allow to let pyFDMNES decide when a new computation of the matrix elements or electron density is necessary.
 
 
 Certainly, FDMNES evolved and not all parameters are correctly represented in the settings file. Therefore it is not complete yet and updates are needed.
@@ -43,6 +43,12 @@ for instance when using MPI:
 FDMNES='mpirun fdmnes'
 FDMNES='/path/to/fdmnes_linux_serial'
 FDMNES='/path/to/fdmnes_linux_parallel'
+```
+
+For instance you may start:
+```
+cd examples/BaTiO3
+FDMNES="mpirun fdmnes_parallel" python3 BaTiO3_cif_open.py
 ```
 The default is to use the executable defined in the `setup.cfg` file of the pyFDMNES package.
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Certainly, FDMNES evolved and not all parameters are correctly represented in th
 - python 2.7 or 3
 - numpy
 - PyCifRW
-- fdmnes (version > March 28th 2014)
+- fdmnes (version > March 28th 2014) from e.g. https://fdmnes.neel.cnrs.fr/
 
 
 # Installation
-change dir to the downloaded repository (where the setup.py is found) and modify the `setup.cfg`
+Change dir to the downloaded repository (where the setup.py is found) and modify the `setup.cfg`.
 
 ## using pip (recommended)
     pip install . [--user]
@@ -35,4 +35,16 @@ change dir to the downloaded repository (where the setup.py is found) and modify
     python setup.py install [--user]
 
 # Usage
-See `examples` folder
+See `examples` folder.
+
+You may set the `FDMNES` environment variable to specify the FDMNES executable command,
+for instance when using MPI:
+```
+FDMNES='mpirun fdmnes'
+FDMNES='/path/to/fdmnes_linux_serial'
+FDMNES='/path/to/fdmnes_linux_parallel'
+```
+The default is to use the executable defined in the `setup.cfg` file of the pyFDMNES package.
+
+You may as well set the `FDMNES_SPACEGROUP` environment variable to specify the `spacegroup.txt` file which defines the space-group operators. The default is to use the file provided by the pyFDMNES package.
+

--- a/fdmnes/pyFDMNES.py
+++ b/fdmnes/pyFDMNES.py
@@ -277,6 +277,10 @@ class fdmnes(object):
                             or
                                 - detailed name of space group 
                                   (including setting)
+            The FDMNES environment variable can be set from the FDMNES
+            environment variable. The space-group list can be set from the 
+            FDMNES_SPACEGROUP environment variable, or defaults to the one from
+            the pyFDMNES package.
         """
         self.positions = collections.OrderedDict() # symmetric unit
         self.Defaults = settings.Defaults

--- a/fdmnes/pyFDMNES.py
+++ b/fdmnes/pyFDMNES.py
@@ -294,33 +294,35 @@ class fdmnes(object):
 
         ### FIND FDMNES ####################################################
         if fdmnes_path==None:
-            if not conf.has_option("global", "fdmnes_path"):
-                raise ValueError(
-                    "No entry for ``fdmnes_path'' found in config file:%s%s"\
-                    %(os.linesep, conffile))
-            else:
+            if conf.has_option("global", "fdmnes_path"):
                 fdmnes_path = conf.get("global", "fdmnes_path")
-
-        fdmnes_path = os.path.realpath(fdmnes_path)
-        print("Using FDMNES at %s"%fdmnes_path)
-        self.fdmnes_dir = os.path.dirname(fdmnes_path)
-        self.fdmnes_exe = fdmnes_path
-        fdmnes_bin = os.path.basename(fdmnes_path)
-
-        for fname in [fdmnes_bin]:
-            fpath = os.path.join(self.fdmnes_dir, fname)
-            if not os.path.isfile(fpath):
+                fdmnes_path = os.path.realpath(fdmnes_path)
+            if os.environ['FDMNES']:
+                fdmnes_path = os.environ['FDMNES']
+            if fdmnes_path is None or not fdmnes_path:
                 raise ValueError(
-                    """
-                        File %s not found in %s
+                    "No valid FDMNES environment variable nor entry for 'fdmnes_path' found in config file:%s%s"\
+                    %(os.linesep, conffile))
 
-                        Have you entered a valid path in %s?
-                        It must point on the fdmnes executable.
-                    """%(fname, self.fdmnes_dir, conffile))
+        print("Using FDMNES %s" % fdmnes_path)
+        # self.fdmnes_dir = os.path.dirname(fdmnes_path)
+        self.fdmnes_exe = fdmnes_path
+        # fdmnes_bin = os.path.basename(fdmnes_path)
 
-        fpath = os.path.join(self.fdmnes_dir, "spacegroup.txt")
-        if not os.path.isfile(fpath):
-            fpath = resource_filename("spacegroup.txt")
+#        for fname in [fdmnes_bin]:
+#            fpath = os.path.join(self.fdmnes_dir, fname)
+#            if not os.path.isfile(fpath):
+#                print(
+#                    """WARNING:
+#                        File %s not found in %s
+
+#                        Have you entered a valid path in %s?
+#                        It must point on the fdmnes executable.
+#                    """%(fname, self.fdmnes_dir, conffile))
+
+#        fpath = os.path.join(self.fdmnes_dir, "spacegroup.txt")
+#        if not os.path.isfile(fpath):
+        fpath = resource_filename("spacegroup.txt")
 
         with open(fpath, "r") as fh:
             sgcont = filter(lambda s: s.startswith("*"), fh.readlines())

--- a/fdmnes/pyFDMNES.py
+++ b/fdmnes/pyFDMNES.py
@@ -297,14 +297,14 @@ class fdmnes(object):
             if conf.has_option("global", "fdmnes_path"):
                 fdmnes_path = conf.get("global", "fdmnes_path")
                 fdmnes_path = os.path.realpath(fdmnes_path)
-            if os.environ['FDMNES']:
+            if 'FDMNES' in os.environ and os.environ['FDMNES']:
                 fdmnes_path = os.environ['FDMNES']
             if fdmnes_path is None or not fdmnes_path:
                 raise ValueError(
                     "No valid FDMNES environment variable nor entry for 'fdmnes_path' found in config file:%s%s"\
                     %(os.linesep, conffile))
 
-        print("Using FDMNES %s" % fdmnes_path)
+        print("Using FDMNES=%s" % fdmnes_path)
         # self.fdmnes_dir = os.path.dirname(fdmnes_path)
         self.fdmnes_exe = fdmnes_path
         # fdmnes_bin = os.path.basename(fdmnes_path)
@@ -323,6 +323,9 @@ class fdmnes(object):
 #        fpath = os.path.join(self.fdmnes_dir, "spacegroup.txt")
 #        if not os.path.isfile(fpath):
         fpath = resource_filename("spacegroup.txt")
+        if 'FDMNES_SPACEGROUP' in os.environ and os.environ['FDMNES_SPACEGROUP'] and os.path.exists(os.environ['FDMNES_SPACEGROUP']):
+          fpath = os.environ['FDMNES_SPACEGROUP']
+        print("Using FDMNES_SPACEGROUP=%s" % fpath)
 
         with open(fpath, "r") as fh:
             sgcont = filter(lambda s: s.startswith("*"), fh.readlines())

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [global]
 ; enter here the path to the fdmnes executable:
-fdmnes_path=/usr/bin/fdmnes_parallel
+fdmnes_path=fdmnes

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def fdmnes_path():
     else:
         fdmnes_path = conf.get("global", "fdmnes_path")
     if not os.path.isfile(fdmnes_path):
-        raise IOError("File not found: {}\Please edit file ``setup.cfg''".format(fdmnes_path))
+        raise IOError("File not found: {}\nPlease edit file ``setup.cfg''".format(fdmnes_path))
     return fdmnes_path
 
 def create_ini(fdmnes_path):


### PR DESCRIPTION
Hello,

This is a proposed contribution to use the `FDMNES` and `FDMNES_SPACEGROUP` environment variables to override the package defaults.
This allows for instance to use FDMNES with MPI with e.g.
```
cd pyFDMNES
python3 -m venv venv-pyfdmnes --system-site-packages
source venv-pyfdmnes
pip install .
cd examples/BaTiO3
FDMNES='mpirun -np 2 fdmnes' python3 BaTiO3_cif_open.py
```

I have updated the README accordingly.
Cheers, Emmanuel from Synchrotron SOLEIL.